### PR TITLE
fix: execution warning

### DIFF
--- a/contracts/UserVerification.sol
+++ b/contracts/UserVerification.sol
@@ -109,7 +109,7 @@ contract UserVerification is Initializable, ERC721Upgradeable, ERC721BurnableUpg
      * @param tokenId ID of the token to be issued
      */
     function issueToken(address user, uint256 tokenId) external onlyManagers {
-        require(!tokenExists(tokenId), "Token already exists");
+        require(_ownerOf(tokenId) == address(0), "Token already exists");
         require(balanceOf(user) == 0, "User already has a token");
 
         _safeMint(user, tokenId);
@@ -123,7 +123,7 @@ contract UserVerification is Initializable, ERC721Upgradeable, ERC721BurnableUpg
      * @param tokenId ID of the token to be revoked
      */
     function revokeToken(uint256 tokenId) external onlyManagers {
-        require(tokenExists(tokenId), "Token does not exist");
+        require(_ownerOf(tokenId) != address(0), "Token does not exist");
         address tokenOwner = ownerOf(tokenId);
         _burn(tokenId);
         delete _userTokens[tokenOwner];
@@ -136,7 +136,7 @@ contract UserVerification is Initializable, ERC721Upgradeable, ERC721BurnableUpg
      * @param tokenId ID of the token whose expiry is to be extended
      */
     function extendTokenExpiry(uint256 tokenId) external onlyManagers {
-        require(tokenExists(tokenId), "Token does not exist");
+        require(_ownerOf(tokenId) != address(0), "Token does not exist");
         _setTokenExpiry(tokenId, block.timestamp + defaultExpiryDuration);
     }
 
@@ -158,7 +158,7 @@ contract UserVerification is Initializable, ERC721Upgradeable, ERC721BurnableUpg
      * @return bool True if the token is expired, false otherwise
      */
     function isTokenExpired(uint256 tokenId) external view returns (bool) {
-        require(tokenExists(tokenId), "Token does not exist");
+        require(_ownerOf(tokenId) != address(0), "Token does not exist");
         return block.timestamp > _tokenExpiryTimes[tokenId];
     }
 
@@ -169,7 +169,7 @@ contract UserVerification is Initializable, ERC721Upgradeable, ERC721BurnableUpg
      * @return uint256 Time in seconds until the token expires, or 0 if it is already expired
      */
     function timeBeforeExpiration(uint256 tokenId) external view returns (uint256) {
-        require(tokenExists(tokenId), "Token does not exist");
+        require(_ownerOf(tokenId) != address(0), "Token does not exist");
 
         if (block.timestamp > _tokenExpiryTimes[tokenId]) {
             return 0;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -20,6 +20,7 @@ const config: HardhatUserConfig = {
         enabled: true,
         runs: 1000000,
       },
+      // https://soliditylang.org/blog/2023/05/10/solidity-0.8.20-release-announcement
       evmVersion: 'shanghai',
     },
   },


### PR DESCRIPTION
Operations were performed with a warning. The reason was that try/catch was used and it resulted in the appearance of the REVERT opcode, which caused the warning. The use of code with try/catch has been removed from the main methods.

https://sepolia-optimism.etherscan.io/tx/0x8496d9615f522747e9b98a1037db5d71a3220fd68adcc44f6ded73856f66c239
